### PR TITLE
Allow mediagoblin_local.ini and paste_local.ini to be editable.

### DIFF
--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -10,8 +10,20 @@ STORAGE=${OPENSHIFT_DATA_DIR}gmg-public
 cd $OPENSHIFT_REPO_DIR/
 
 ## MG recommends not editing these files in place
-cp paste.ini paste_local.ini
-cp mediagoblin.ini mediagoblin_local.ini
+mkdir -p ${OPENSHIFT_DATA_DIR}config
+function prep_local_config {
+    if [[ ! -f "${OPENSHIFT_DATA_DIR}config/${1}_local.ini" ]]
+    then
+        # create the locals in ${OPENSHIFT_DATA_DIR}config if they don't exist
+        cp -- "${1}.ini" "${OPENSHIFT_DATA_DIR}config/${1}_local.ini"
+    fi
+
+    # copy locals from ${OPENSHIFT_DATA_DIR}config to deploy directory
+    cp -- "${OPENSHIFT_DATA_DIR}config/${1}_local.ini" "${1}_local.ini"
+}
+
+prep_local_config mediagoblin
+prep_local_config paste
 
 ## if not already done, add a paster config
 if [ $(grep -c openshift paste_local.ini) -ne 1 ]


### PR DESCRIPTION
As I understand, mediagoblin_local.ini and paste_local.ini are supposed to be untracked files that allow for the deployer to configure mediagoblin in a custom way, to avoid needing to commit such changes to the repository.

Ideally I would think that the best way to do a deployment would be to only copy the .ini to their _local counterparts when they don't already exist, and not clobber them otherwise. However it seems that Openshift (understandably) cleans out the entire REPO directory on each deploy. So what I did was make it first copy mediagoblin.ini and paste.ini to the _local versions in the DATA directory, under the directory config/, if they don't exist yet. Then, I (always) copy _those_ files into the _local files in the REPO directory. That way, if you're just starting, a basic version shows up in data/config. If you edit the files in data/config, they will be applied when you subsequently deploy, and won't get clobbered.

It looks like you add some custom stuff to the end of the .ini files. This should still happen on top of whatever custom stuff the deployer puts into it in the data/custom/ copy, every time.

Let me know what you think. I basically just guessed that the data directory would be the best place. In any case this is what I'm doing for now with my own deployment I'm playing with.
